### PR TITLE
Changed "Our Department" description

### DIFF
--- a/app/templates/pages/home.html
+++ b/app/templates/pages/home.html
@@ -48,7 +48,7 @@
                 </div>
                 <div class="panel-body">
                     <h4>Our Department</h4>
-                    <p>With our agile community centered processes we are flexible and fast enough to respond to volunteer requests.</p>
+                    <p>We are 3 agile teams working at the Wikimedia DE office in Berlin.</p>
                     <a href="#" class="btn btn-primary disabled">Learn More</a>
                 </div>
             </div>


### PR DESCRIPTION
Main reason: all other descriptions where 2 lines and this one was 4,
which made the layout look quite silly.

Secondary reason: the other description was kinda fluff, and more about
how we work (and what we do (already under "Our Projects")) than who
we are.