### PR TITLE
Fixing the link to the technical wishes board

### DIFF
--- a/app/templates/pages/projects.html
+++ b/app/templates/pages/projects.html
@@ -66,7 +66,7 @@
 
             <p><strong>Technologies:</strong> MediaWiki, PHP, JavaScript</p>
 
-            <a class="btn btn-primary" href="https://phabricator.wikimedia.org/tag/german-community-wishlist/">Contribute Now</a>
+            <a class="btn btn-primary" href="https://phabricator.wikimedia.org/project/view/2084/">Contribute Now</a>
         </div>
     </div>
 


### PR DESCRIPTION
Currently there are two projects on Phabricator where technical wishes
are organized: German-Community-Wishlist and
German-Community-Whishlist-Main-Wishes. The latter is more up-to-date and
gives a better overview of the current state of the wishes.