### PR TITLE
Join paragraphs and remove focus on gender

### DIFF
--- a/app/templates/job-layout.html
+++ b/app/templates/job-layout.html
@@ -38,10 +38,7 @@
             <p>
                 Wikimedia Deutschland commits itself to the principles of equal opportunity and does not discriminate on the basis of
                 ethnic origin, nationality, religion, political or other opinion, sex, age, disability or sexual identity or orientation.
-            </p>
-
-            <p>
-                In light of an underrepresentation of women in our Software Development Department we strongly encourage qualified women to apply.                
+                We strongly encourage individuals from groups traditionally underrepresented in tech to apply.
             </p>
         </div>
     </div>


### PR DESCRIPTION
I was originally going to comment that I liked this note which I found on a great job description better than what we have since 2 weeks ago:

> We are an equal-opportunity employer and value diversity. We consider all applications equally regardless of race, color, ancestry, religion, sex, national origin, sexual orientation, age, citizenship, marital status, disability, or gender identity. We strongly encourage individuals from groups traditionally underrepresented in tech to apply, and we can help with immigration.

The main reason being that they start by saying they are about equal opportunity and do not discriminate. Which we apparently already have. I was not clued in to that when commenting on https://github.com/wmde/software.wikimedia.de/pull/94

Still can steal their more general sentence :)